### PR TITLE
Add experimental X live detection

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -113,6 +113,9 @@ YOUTUBE_API_KEY=
 # Interval for getting live streams
 LIVE_STREAM_INTERVAL=5
 
+# Experimental X live detection. Uses Playwright to check X profiles for live Spaces/broadcasts.
+X_LIVE_CHECK_ENABLED=false
+
 # Max number of cohosts for a page
 MAX_COHOSTS=5
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -13,6 +13,7 @@ docker-compose.build.yml
 migrations/data/*.json
 typeorm.server.config.ts
 /backups
+/.cache
 
 # Logs
 logs

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -57,6 +57,7 @@
         "passport-jwt": "^4.0.1",
         "patch-package": "^8.0.0",
         "pg": "^8.13.0",
+        "playwright": "1.54.1",
         "redis": "^4.7.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -11557,6 +11558,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/server/package.json
+++ b/server/package.json
@@ -76,6 +76,7 @@
     "passport-jwt": "^4.0.1",
     "patch-package": "^8.0.0",
     "pg": "^8.13.0",
+    "playwright": "1.54.1",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/server/src/live-streams/live-streams.module.ts
+++ b/server/src/live-streams/live-streams.module.ts
@@ -18,6 +18,7 @@ import { PeertubeModule } from 'src/integrations/peertube/peertube.module';
 import { PeertubeProvider } from './providers/peertube.provider';
 import { KickModule } from 'src/integrations/kick/kick.module';
 import { KickProvider } from './providers/kick.provider';
+import { XProvider } from './providers/x.provider';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { KickProvider } from './providers/kick.provider';
     YoutubeProvider,
     TwitchProvider,
     KickProvider,
+    XProvider,
     RumbleProvider,
     PeertubeProvider,
     LiveStreamProcessor,

--- a/server/src/live-streams/live-streams.service.ts
+++ b/server/src/live-streams/live-streams.service.ts
@@ -20,6 +20,7 @@ import { Link } from 'src/links/link.entity';
 import { Tip } from 'src/tips/tip.entity';
 import { PeertubeProvider } from './providers/peertube.provider';
 import { KickProvider } from './providers/kick.provider';
+import { XProvider } from './providers/x.provider';
 
 @Injectable()
 export class LiveStreamsService implements OnModuleInit {
@@ -30,6 +31,7 @@ export class LiveStreamsService implements OnModuleInit {
     private youtubeProvider: YoutubeProvider,
     private twitchProvider: TwitchProvider,
     private kickProvider: KickProvider,
+    private xProvider: XProvider,
     private rumbleProvider: RumbleProvider,
     private peertubeProvider: PeertubeProvider,
     private config: ConfigService,
@@ -103,6 +105,7 @@ export class LiveStreamsService implements OnModuleInit {
     const youtube = await this.getYoutubeLiveStreams();
     const twitch = await this.getTwitchLiveStreams();
     const kick = await this.getKickLiveStreams();
+    const x = await this.getXLiveStreams();
     const rumble = await this.getRumbleLiveStreams();
     const peertube = await this.getPeertubeLiveStreams();
 
@@ -110,6 +113,7 @@ export class LiveStreamsService implements OnModuleInit {
       ...youtube,
       ...twitch,
       ...kick,
+      ...x,
       ...rumble,
       ...peertube,
     ]);
@@ -233,5 +237,50 @@ export class LiveStreamsService implements OnModuleInit {
 
   async getPeertubeLiveStreams() {
     return this.peertubeProvider.getLiveStreams();
+  }
+
+  async getXProviderParams() {
+    const links = await this.linksService.findByPlatform(LinkPlatformEnum.X);
+    if (!links.length) return [];
+
+    const streamableLinkPlatforms = [
+      LinkPlatformEnum.YOUTUBE,
+      LinkPlatformEnum.TWITCH,
+      LinkPlatformEnum.KICK,
+      LinkPlatformEnum.RUMBLE,
+      LinkPlatformEnum.PEERTUBE,
+    ];
+
+    const streamableLinks = await Promise.all(
+      streamableLinkPlatforms.map((platform) =>
+        this.linksService.findByPlatform(platform),
+      ),
+    );
+    const streamablePageIds = new Set(
+      streamableLinks.flat().map((link) => link.page.id),
+    );
+
+    const twitchPages = await this.pagesRepo.find({
+      where: {
+        twitchChannel: And(Not(IsNull()), Not('')),
+        isPublic: true,
+        status: Not(PageStatusEnum.DEACTIVE),
+      },
+    });
+    twitchPages.forEach((page) => streamablePageIds.add(page.id));
+
+    return links
+      .filter((link) => !streamablePageIds.has(link.page.id))
+      .map((link) => ({
+        username: link.value,
+        pageId: link.page.id,
+      }));
+  }
+
+  async getXLiveStreams() {
+    if (!this.xProvider.isEnabled()) return [];
+
+    const params = await this.getXProviderParams();
+    return this.xProvider.getLiveStreams(params);
   }
 }

--- a/server/src/live-streams/providers/x.provider.ts
+++ b/server/src/live-streams/providers/x.provider.ts
@@ -1,0 +1,263 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type {
+  APIRequestContext,
+  BrowserContext,
+  Page,
+  Response,
+} from 'playwright';
+import { chromium, request } from 'playwright';
+import { LiveStreamPlatformEnum } from 'src/shared/constants';
+import { getErrorMessage } from 'src/shared/utils/errors';
+import { CreateLiveStreamDto } from '../dtos/create-live-stream.dto';
+import {
+  LiveStreamProvider,
+  LiveStreamProviderParams,
+} from './live-stream-provider.interface';
+
+type XProviderParam = LiveStreamProviderParams & { username: string };
+type XLiveLink = { url: string; title?: string };
+type XRecord = Record<string, any>;
+
+@Injectable()
+export class XProvider implements LiveStreamProvider, OnModuleDestroy {
+  private readonly logger = new Logger(XProvider.name);
+  private context?: BrowserContext;
+  private requestContext?: APIRequestContext;
+
+  constructor(private readonly config: ConfigService) {}
+
+  async onModuleDestroy() {
+    await this.context?.close().catch(() => undefined);
+    await this.requestContext?.dispose().catch(() => undefined);
+  }
+
+  async getLiveStreams(
+    params: LiveStreamProviderParams[],
+  ): Promise<CreateLiveStreamDto[]> {
+    if (!this.isEnabled()) return [];
+
+    const streams: CreateLiveStreamDto[] = [];
+    // Check one profile at a time to limit load on X.
+    for (const param of params) {
+      if (!param.username || !/^[a-zA-Z0-9_]{1,15}$/.test(param.username))
+        continue;
+      const stream = await this.getLiveStream(param as XProviderParam);
+      if (stream) streams.push(stream);
+    }
+    return streams;
+  }
+
+  private async getLiveStream(
+    param: XProviderParam,
+  ): Promise<CreateLiveStreamDto | undefined> {
+    let page: Page | undefined;
+    try {
+      const profileUrl = `https://x.com/${param.username}`;
+      let liveLink = await this.findLiveLinkByRequest(
+        profileUrl,
+        param.username,
+      );
+      if (!liveLink) {
+        const context = await this.getContext();
+        page = await context.newPage();
+        const pending = new Set<Promise<void>>();
+        const onResponse = (response: Response) => {
+          const url = new URL(response.url());
+          if (
+            !response.ok() ||
+            !['x.com', 'api.x.com', 'twitter.com', 'api.twitter.com'].includes(
+              url.hostname,
+            ) ||
+            !/json|html/.test(response.headers()['content-type'] || '')
+          )
+            return;
+          const read = response
+            .text()
+            .then((body) => {
+              liveLink ||= this.findLiveLinkInResponse(body, param.username);
+            })
+            .catch(() => undefined);
+          pending.add(read);
+          void read.finally(() => pending.delete(read));
+        };
+        page.on('response', onResponse);
+        await page.goto(profileUrl, {
+          waitUntil: 'domcontentloaded',
+          timeout: 15000,
+        });
+        await page.waitForTimeout(2500);
+        page.off('response', onResponse);
+        // Bound response-body reads too, so a stalled response cannot block refresh.
+        let timer: ReturnType<typeof setTimeout>;
+        try {
+          await Promise.race([
+            Promise.all(pending),
+            new Promise<void>((resolve) => {
+              timer = setTimeout(resolve, 2500);
+            }),
+          ]);
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+      if (!liveLink) return;
+      return {
+        pageId: param.pageId,
+        title: liveLink.title || `${param.username} is live on X`,
+        description: 'Live on X',
+        channelName: param.username,
+        channelId: param.username,
+        videoId: liveLink.url,
+        platform: LiveStreamPlatformEnum.X,
+        startedAt: new Date().toISOString(),
+        data: { url: liveLink.url, profileUrl },
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Failed to check X live status for ${param.username}: ${getErrorMessage(error)}`,
+      );
+    } finally {
+      await page?.close().catch(() => undefined);
+    }
+  }
+
+  private async findLiveLinkByRequest(profileUrl: string, username: string) {
+    try {
+      this.requestContext ||= await request.newContext({
+        userAgent:
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36',
+      });
+      const response = await this.requestContext.get(profileUrl, {
+        timeout: 15000,
+      });
+      try {
+        if (!response.ok()) {
+          this.logger.warn(
+            `X profile request returned ${response.status()} for ${username}`,
+          );
+          return;
+        }
+        return this.findLiveLinkInResponse(await response.text(), username);
+      } finally {
+        await response.dispose();
+      }
+    } catch (error) {
+      this.logger.warn(
+        `X profile request failed for ${username}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private findLiveLinkInResponse(
+    body: string,
+    username: string,
+  ): XLiveLink | undefined {
+    // JSON API responses contain nested records; SSR responses use Relay references.
+    let data: unknown;
+    try {
+      data = JSON.parse(body);
+    } catch {
+      return this.findLiveLinkInRelayResponse(body, username);
+    }
+    const visit = (value: unknown): XLiveLink | undefined => {
+      if (!value || typeof value !== 'object') return;
+      const record = value as XRecord;
+      const liveLink = this.liveLinkFromRecord(record, username);
+      if (liveLink) return liveLink;
+      for (const child of Object.values(record)) {
+        const result = visit(child);
+        if (result) return result;
+      }
+    };
+    return visit(data);
+  }
+
+  private findLiveLinkInRelayResponse(body: string, username: string) {
+    const records = new Map<string, XRecord>();
+    // Read scalar fields and Relay references from X's serialized response data.
+    // Never execute the scripts received from X or infer live status from link text.
+    for (const script of body.matchAll(
+      /<script\b[^>]*>([\s\S]*?)<\/script>/gi,
+    )) {
+      for (const match of script[1].matchAll(
+        /\{__id:("(?:\\.|[^"\\])*"),__typename:("(?:\\.|[^"\\])*")([\s\S]*?)(?=\{__id:|$)/g,
+      )) {
+        const record: XRecord = { __typename: JSON.parse(match[2]) };
+        for (const field of match[3].matchAll(
+          /[,{}](\w+):("(?:\\.|[^"\\])*"|null|\d+|\$R\[\d+\]=\{__ref:("(?:\\.|[^"\\])*")\})/g,
+        )) {
+          record[field[1]] = field[3]
+            ? { __ref: JSON.parse(field[3]) }
+            : JSON.parse(field[2]);
+        }
+        records.set(JSON.parse(match[1]), record);
+      }
+    }
+    const resolve = (value: XRecord | undefined): XRecord | undefined =>
+      value?.__ref ? records.get(value.__ref) : value;
+    for (const record of records.values()) {
+      const liveLink = this.liveLinkFromRecord(record, username, resolve);
+      if (liveLink) return liveLink;
+    }
+  }
+
+  private liveLinkFromRecord(
+    record: XRecord,
+    username: string,
+    resolve: (value: XRecord | undefined) => XRecord | undefined = (value) =>
+      value,
+  ): XLiveLink | undefined {
+    const metadata = resolve(record.metadata) || record;
+    if (metadata.state !== 'Running') return;
+    const isBroadcast =
+      record.__typename === 'Broadcast' || Boolean(record.broadcast_id);
+    const isSpace = record.__typename === 'AudioSpace';
+    if (!isBroadcast && !isSpace) return;
+
+    const userResults = resolve(
+      metadata.user_results || metadata.creator_results,
+    );
+    const user = resolve(userResults?.result);
+    const core = resolve(user?.core);
+    const legacy = resolve(user?.legacy);
+    const periscopeUser = resolve(record.periscope_user);
+    const owner =
+      core?.screen_name || legacy?.screen_name || periscopeUser?.username;
+    if (
+      typeof owner !== 'string' ||
+      owner.toLowerCase() !== username.toLowerCase()
+    )
+      return;
+
+    const id = isBroadcast ? record.broadcast_id : record.rest_id;
+    if (typeof id !== 'string' || !/^[a-zA-Z0-9]+$/.test(id)) return;
+    const title = isBroadcast ? record.status : metadata.title;
+    return {
+      url: `https://x.com/i/${isBroadcast ? 'broadcasts' : 'spaces'}/${id}`,
+      title: typeof title === 'string' ? title.slice(0, 240) : undefined,
+    };
+  }
+
+  private async getContext() {
+    if (this.context) return this.context;
+    this.context = await chromium.launchPersistentContext(
+      '.cache/x-live-browser',
+      {
+        headless: true,
+        chromiumSandbox: false,
+        args: ['--no-sandbox', '--disable-dev-shm-usage'],
+      },
+    );
+    return this.context;
+  }
+
+  isEnabled() {
+    const value = this.config.get<string | boolean>('X_LIVE_CHECK_ENABLED');
+    if (typeof value === 'boolean') return value;
+    return (
+      typeof value === 'string' &&
+      ['true', '1', 'yes', 'on'].includes(value.toLowerCase())
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Add experimental X live detection for public creator pages that have an X link and no other supported streaming platform. Detected broadcasts and Spaces join the existing Live Now refresh.

Use Playwright's HTTP request API to read structured X profile response data, with headless browser network responses as a fallback. Require a running state and a matching creator before returning a stream. Keep only X_LIVE_CHECK_ENABLED as an environment setting; the provider uses fixed defaults.

## Validation
- Backend build and provider formatting checks pass.
- Live checks on September 9, 2026 detected @espn975 and @AJNlive. AJNlive appeared in the local app's Live Now results: https://x.com/i/broadcasts/1wxWjlnZXkqJQ.
- Focused local checks cover captured profile data, wrong owners, ended broadcasts, replay text, login walls, JSON broadcast/Space data, scheduled Spaces, feature flags, invalid usernames, and response cleanup.
- Controlled Chromium network tests cover running/ended broadcasts and page cleanup.
- Service checks cover X-only eligibility, other-platform exclusions (including legacy Twitch), the disabled gate, and combined refresh.

## Limitations
X may block requests or change its response format. Spaces were checked with fixtures, not a currently live Space. The local homepage and AJNlive creator page were checked in Chromium without JavaScript errors; payment flows were not tested. The repository's existing ESLint invocation fails to parse TypeScript imports; its configuration was left unchanged.
